### PR TITLE
新增圖表

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>火箭套票網</title>
     <link rel="stylesheet" href="./src/styles/style.css" />
+
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.18/c3.css"
+    />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/5.16.0/d3.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.7.18/c3.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/1.1.3/axios.min.js"></script>
   </head>
   <body>
@@ -151,14 +158,17 @@
     <section class="main-content">
       <!-- 搜尋區 -->
       <div class="search-area">
-        <select name="" class="regionSearch">
-          <option value="地區搜尋" disabled selected hidden>地區搜尋</option>
-          <option value="">全部地區</option>
-          <option value="台北">台北</option>
-          <option value="台中">台中</option>
-          <option value="高雄">高雄</option>
-        </select>
-        <p id="searchResult-text">本次搜尋共 3 筆資料</p>
+        <div class="search-wrapper">
+          <select name="" class="regionSearch">
+            <option value="地區搜尋" disabled selected hidden>地區搜尋</option>
+            <option value="">全部地區</option>
+            <option value="台北">台北</option>
+            <option value="台中">台中</option>
+            <option value="高雄">高雄</option>
+          </select>
+          <p id="searchResult-text">本次搜尋共 3 筆資料</p>
+        </div>
+        <div class="chart"></div>
       </div>
       <!-- 套票卡片區 -->
       <ul class="ticketCard-area"></ul>

--- a/src/scripts/chart.js
+++ b/src/scripts/chart.js
@@ -1,0 +1,44 @@
+export default function showChart(data, chart) {
+  chart?.destroy();
+
+  const newData = {};
+  const order = ["台北", "台中", "高雄"];
+
+  data.forEach((item) => {
+    if (newData[item.area]) {
+      ++newData[item.area];
+    } else {
+      newData[item.area] = 1;
+    }
+  });
+
+  console.log(newData);
+  return c3.generate({
+    bindto: ".chart", // HTML 元素綁定
+    size: {
+      height: 200,
+      width: 200,
+    },
+
+    data: {
+      labels: false,
+      type: "donut",
+      columns: order
+        .map((item) => [item, newData[item] || 0])
+        .filter(([, value]) => value !== 0),
+      colors: {
+        台北: "#26C0C7",
+        台中: "#5151D3",
+        高雄: "#E68618",
+      },
+    },
+
+    donut: {
+      title: "套票地區比重",
+      width: 12,
+      label: {
+        show: false,
+      },
+    },
+  });
+}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -7,9 +7,13 @@ import {
   searchNum,
 } from "./elements.js";
 import { validateForm, showList } from "./utils.js";
+import showChart from "./chart.js";
 
 // 把原本的 import 的 data 變數改為此處宣告，等待初始化後把 fetch 到的資料存進來
 const data = [];
+
+// 圖表元素先宣告但不載入
+let chart = null;
 
 // 新增套票
 addButton.addEventListener("click", () => {
@@ -36,6 +40,9 @@ addButton.addEventListener("click", () => {
     Object.values(form).forEach((item) => {
       item.value = null;
     });
+
+    // 顯示新圖表
+    chart = showChart(data, chart);
   }
 });
 
@@ -44,6 +51,8 @@ addButton.addEventListener("click", () => {
 fetchData().then((res) => {
   res.forEach((item) => data.push(item));
   ticketList.innerHTML = showList(data.slice(0, 3));
+
+  chart = showChart(data);
 });
 
 searchNum.textContent = "";
@@ -57,8 +66,13 @@ regionSearch.addEventListener("change", (e) => {
     const targetList = data.filter((item) => item.area === e.target.value);
     ticketList.innerHTML = showList(targetList);
     length = targetList.length;
+
+    // 依照篩選的地區顯示圖表
+    chart = showChart(targetList, chart);
   } else {
     ticketList.innerHTML = showList(data);
+
+    chart = showChart(data, chart);
   }
 
   searchNum.textContent = `本次搜尋共 ${length} 筆資料`;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -240,16 +240,33 @@ body {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  justify-content: space-between;
   -webkit-box-align: center;
   -ms-flex-align: center;
-  align-items: center;
+  align-items: flex-start;
   max-width: 920px;
   margin: 0 auto;
   padding: 50px 0;
 }
 
+.search-wrapper {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
 .search-area p {
   color: #818a91;
+}
+
+.chart {
+  margin: 0 auto;
+}
+
+.chart .c3-chart-arcs-title,
+.chart .c3-legend-item-event {
+  font-size: 14px;
+  font-weight: 400;
 }
 
 @media (max-width: 768px) {
@@ -261,6 +278,10 @@ body {
     -webkit-box-pack: center;
     -ms-flex-pack: center;
     justify-content: center;
+  }
+
+  .search-wrapper {
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
1. CDN 載入 C3.js
2. 將顯示圖表的函式 showChart 打包成 module 並引入
3. 函式可以傳入兩個參數：套票資料 data、圖表變數 chart
4. 對 data 處理後就可以呼叫 C3 生成圖表，資料定義在 C3 的模型的 columns 裡
5. columns 透過陣列方法產生 [ key, value]，value 為 0 的地區不顯示
6. 函式會回傳這個圖表模型，在主程式 main.js 裡用 let chart 儲存
7. 如新增套票或篩選地需後圖表需要更新，把變數 chart 利用呼叫 showChart 重新賦值，並且把當前的 chart 傳入
8. showChart 一開始用可選串連檢查 chart 是否存在，再用 destroy 方法清空圖表（不清空是不能在同個 HTML 元素下生成的）